### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/JAMFConnect/JamfConnectConfiguration.pkg.recipe
+++ b/JAMFConnect/JamfConnectConfiguration.pkg.recipe
@@ -2,45 +2,43 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Transfers the package from the pre-downloaded DMG.</string>
-    <key>Identifier</key>
-    <string>com.github.yohan460-recipes.pkg.JamfConnectConfiguration</string>
-    <key>Input</key>
-    <dict>
-        <key>APP_FILENAME</key>
-        <string>Jamf Connect Configuration</string>
-        <key>BUNDLE_ID</key>
-        <string>com.jamf.connect.configuration</string>
-        <key>NAME</key>
-        <string>JamfConnectConfiguration</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>1.0.0</string>
-    <key>ParentRecipe</key>
-    <string>com.github.yohan460-recipes.download.JamfConnect</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_path</key>
-                <string>%pathname%/* Configuration.app</string>
-                <key>requirement</key>
-                <string>anchor apple generic and identifier "com.jamf.connect.configuration" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "483DWKW443")</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>app_path</key>
-                <string>%pathname%/* Configuration.app</string>
-            </dict>
-            <key>Processor</key>
-            <string>AppPkgCreator</string>
-        </dict>
-    </array>
+	<key>Description</key>
+	<string>Transfers the package from the pre-downloaded DMG.</string>
+	<key>Identifier</key>
+	<string>com.github.yohan460-recipes.pkg.JamfConnectConfiguration</string>
+	<key>Input</key>
+	<dict>
+		<key>APP_FILENAME</key>
+		<string>Jamf Connect Configuration</string>
+		<key>NAME</key>
+		<string>JamfConnectConfiguration</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.yohan460-recipes.download.JamfConnect</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/* Configuration.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.jamf.connect.configuration" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "483DWKW443")</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>app_path</key>
+				<string>%pathname%/* Configuration.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/JAMFConnect/JamfConnectLogin.pkg.recipe
+++ b/JAMFConnect/JamfConnectLogin.pkg.recipe
@@ -2,99 +2,97 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Transfers the package from the pre-downloaded DMG.</string>
-    <key>Identifier</key>
-    <string>com.github.yohan460-recipes.pkg.JamfConnectLogin</string>
-    <key>Input</key>
-    <dict>
-        <key>APP_FILENAME</key>
-        <string>Jamf Connect Login</string>
-        <key>BUNDLE_ID</key>
-        <string>com.jamf.connect.login</string>
-        <key>NAME</key>
-        <string>JamfConnectLogin</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>1.0.0</string>
-    <key>ParentRecipe</key>
-    <string>com.github.yohan460-recipes.download.JamfConnect</string>
-    <key>Process</key>
-    <array>
-        <dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
+	<key>Description</key>
+	<string>Transfers the package from the pre-downloaded DMG.</string>
+	<key>Identifier</key>
+	<string>com.github.yohan460-recipes.pkg.JamfConnectLogin</string>
+	<key>Input</key>
+	<dict>
+		<key>APP_FILENAME</key>
+		<string>Jamf Connect Login</string>
+		<key>NAME</key>
+		<string>JamfConnectLogin</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.yohan460-recipes.download.JamfConnect</string>
+	<key>Process</key>
+	<array>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: JAMF Software (483DWKW443)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
 				<key>input_path</key>
 				<string>%pathname%/* Login/*.pkg</string>
-                <key>expected_authority_names</key>
-                <array>
-                    <string>Developer ID Installer: JAMF Software (483DWKW443)</string>
-                    <string>Developer ID Certification Authority</string>
-                    <string>Apple Root CA</string>
-                </array>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>FlatPkgUnpacker</string>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>flat_pkg_path</key>
 				<string>%pathname%/* Login/*.pkg</string>
-                <key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack</string>
-                <key>purge_destination</key>
-                <true/>
+				<key>purge_destination</key>
+				<true/>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>Copier</string>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
+				<key>overwrite</key>
+				<true/>
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/*.pkg/Payload</string>
-                <key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
-                <key>overwrite</key>
-                <true/>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>PkgPayloadUnpacker</string>
+			<string>Copier</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
 				<key>pkg_payload_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
-                <key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload</string>
-                <key>purge_destination</key>
-                <true/>
+				<key>purge_destination</key>
+				<true/>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>PlistReader</string>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
 				<string>%RECIPE_CACHE_DIR%/payload/Library/Security/SecurityAgentPlugins/JamfConnectLogin.bundle/Contents/Info.plist</string>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>PkgCopier</string>
+			<string>PlistReader</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				<key>source_pkg</key>
 				<string>%pathname%/* Login/*.pkg</string>
-                <key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
 		</dict>
-    </array>
+	</array>
 </dict>
 </plist>

--- a/JAMFConnect/JamfConnectSync.pkg.recipe
+++ b/JAMFConnect/JamfConnectSync.pkg.recipe
@@ -2,99 +2,97 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Transfers the package from the pre-downloaded DMG.</string>
-    <key>Identifier</key>
-    <string>com.github.yohan460-recipes.pkg.JamfConnectSync</string>
-    <key>Input</key>
-    <dict>
-        <key>APP_FILENAME</key>
-        <string>Jamf Connect Sync</string>
-        <key>BUNDLE_ID</key>
-        <string>com.jamf.connect.sync</string>
-        <key>NAME</key>
-        <string>JamfConnectSync</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>1.0.0</string>
-    <key>ParentRecipe</key>
-    <string>com.github.yohan460-recipes.download.JamfConnect</string>
-    <key>Process</key>
-    <array>
-        <dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
+	<key>Description</key>
+	<string>Transfers the package from the pre-downloaded DMG.</string>
+	<key>Identifier</key>
+	<string>com.github.yohan460-recipes.pkg.JamfConnectSync</string>
+	<key>Input</key>
+	<dict>
+		<key>APP_FILENAME</key>
+		<string>Jamf Connect Sync</string>
+		<key>NAME</key>
+		<string>JamfConnectSync</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.yohan460-recipes.download.JamfConnect</string>
+	<key>Process</key>
+	<array>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: JAMF Software (483DWKW443)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
 				<key>input_path</key>
 				<string>%pathname%/* Sync/*.pkg</string>
-                <key>expected_authority_names</key>
-                <array>
-                    <string>Developer ID Installer: JAMF Software (483DWKW443)</string>
-                    <string>Developer ID Certification Authority</string>
-                    <string>Apple Root CA</string>
-                </array>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>FlatPkgUnpacker</string>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>flat_pkg_path</key>
 				<string>%pathname%/* Sync/*.pkg</string>
-                <key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack</string>
-                <key>purge_destination</key>
-                <true/>
+				<key>purge_destination</key>
+				<true/>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>Copier</string>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
+				<key>overwrite</key>
+				<true/>
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/*.pkg/Payload</string>
-                <key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
-                <key>overwrite</key>
-                <true/>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>PkgPayloadUnpacker</string>
+			<string>Copier</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
 				<key>pkg_payload_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
-                <key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload</string>
-                <key>purge_destination</key>
-                <true/>
+				<key>purge_destination</key>
+				<true/>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>PlistReader</string>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
 				<string>%RECIPE_CACHE_DIR%/payload/Applications/Jamf Connect Sync.app/Contents/Info.plist</string>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>PkgCopier</string>
+			<string>PlistReader</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				<key>source_pkg</key>
 				<string>%pathname%/* Sync/*.pkg</string>
-                <key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
 		</dict>
-    </array>
+	</array>
 </dict>
 </plist>

--- a/JAMFConnect/JamfConnectVerify.pkg.recipe
+++ b/JAMFConnect/JamfConnectVerify.pkg.recipe
@@ -2,99 +2,97 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Transfers the package from the pre-downloaded DMG.</string>
-    <key>Identifier</key>
-    <string>com.github.yohan460-recipes.pkg.JamfConnectVerify</string>
-    <key>Input</key>
-    <dict>
-        <key>APP_FILENAME</key>
-        <string>Jamf Connect Verify</string>
-        <key>BUNDLE_ID</key>
-        <string>com.jamf.connect.verify</string>
-        <key>NAME</key>
-        <string>JamfConnectVerify</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>1.0.0</string>
-    <key>ParentRecipe</key>
-    <string>com.github.yohan460-recipes.download.JamfConnect</string>
-    <key>Process</key>
-    <array>
-        <dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
+	<key>Description</key>
+	<string>Transfers the package from the pre-downloaded DMG.</string>
+	<key>Identifier</key>
+	<string>com.github.yohan460-recipes.pkg.JamfConnectVerify</string>
+	<key>Input</key>
+	<dict>
+		<key>APP_FILENAME</key>
+		<string>Jamf Connect Verify</string>
+		<key>NAME</key>
+		<string>JamfConnectVerify</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.yohan460-recipes.download.JamfConnect</string>
+	<key>Process</key>
+	<array>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: JAMF Software (483DWKW443)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
 				<key>input_path</key>
 				<string>%pathname%/* Verify/*.pkg</string>
-                <key>expected_authority_names</key>
-                <array>
-                    <string>Developer ID Installer: JAMF Software (483DWKW443)</string>
-                    <string>Developer ID Certification Authority</string>
-                    <string>Apple Root CA</string>
-                </array>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>FlatPkgUnpacker</string>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>flat_pkg_path</key>
 				<string>%pathname%/* Verify/*.pkg</string>
-                <key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack</string>
-                <key>purge_destination</key>
-                <true/>
+				<key>purge_destination</key>
+				<true/>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>Copier</string>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
+				<key>overwrite</key>
+				<true/>
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/*.pkg/Payload</string>
-                <key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
-                <key>overwrite</key>
-                <true/>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>PkgPayloadUnpacker</string>
+			<string>Copier</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
 				<key>pkg_payload_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
-                <key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload</string>
-                <key>purge_destination</key>
-                <true/>
+				<key>purge_destination</key>
+				<true/>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>PlistReader</string>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
 				<string>%RECIPE_CACHE_DIR%/payload/Applications/Jamf Connect Verify.app/Contents/Info.plist</string>
 			</dict>
-		</dict>
-        <dict>
 			<key>Processor</key>
-			<string>PkgCopier</string>
+			<string>PlistReader</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				<key>source_pkg</key>
 				<string>%pathname%/* Verify/*.pkg</string>
-                <key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
 		</dict>
-    </array>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Because an automated script helped make this change, modified recipes have also been converted to align with the output of `plutil -convert xml` and Python's `plistlib`. This results in reordering of dictionary keys and reindentation using tabs, neither of which will affect the recipe's function.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ JAMFConnect/JamfConnectConfiguration.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/Yohan460-recipes/JAMFConnect/JamfConnectConfiguration.pkg.recipe
Processing repos/Yohan460-recipes/JAMFConnect/JamfConnectConfiguration.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Jamf Connect Configuration.dmg',
           'url': 'https://files.jamfconnect.com/JamfConnect.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectConfiguration/downloads/Jamf Connect Configuration.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectConfiguration/downloads/Jamf '
                        'Connect Configuration.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectConfiguration/downloads/Jamf '
                         'Connect Configuration.dmg/* Configuration.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.jamf.connect.configuration" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "483DWKW443")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectConfiguration/downloads/Jamf Connect Configuration.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.3begTX/Jamf Connect Configuration.app' matched from globbed '/private/tmp/dmg.3begTX/* Configuration.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.3begTX/Jamf Connect Configuration.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.3begTX/Jamf Connect Configuration.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.3begTX/Jamf Connect Configuration.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectConfiguration/downloads/Jamf '
                       'Connect Configuration.dmg/* Configuration.app'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectConfiguration/downloads/Jamf Connect Configuration.dmg
AppPkgCreator: Using path '/private/tmp/dmg.4JIaXP/Jamf Connect Configuration.app' matched from globbed '/private/tmp/dmg.4JIaXP/* Configuration.app'.
AppPkgCreator: Version: 2.2.1
AppPkgCreator: BundleID: com.jamf.connect.configuration
AppPkgCreator: Copied /private/tmp/dmg.4JIaXP/Jamf Connect Configuration.app to ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectConfiguration/payload/Applications/Jamf Connect Configuration.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.jamf.connect.configuration',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectConfiguration/Jamf '
                                                                    'Connect '
                                                                    'Configuration-2.2.1.pkg',
                                                        'version': '2.2.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.2.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectConfiguration/receipts/JamfConnectConfiguration.pkg-receipt-20210213-233511.plist

The following packages were built:
    Identifier                      Version  Pkg Path                                                                                                                            
    ----------                      -------  --------                                                                                                                            
    com.jamf.connect.configuration  2.2.1    ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectConfiguration/Jamf Connect Configuration-2.2.1.pkg  
```

## ❌ JAMFConnect/JamfConnectLogin.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/Yohan460-recipes/JAMFConnect/JamfConnectLogin.pkg.recipe
Processing repos/Yohan460-recipes/JAMFConnect/JamfConnectLogin.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Jamf Connect Login.dmg',
           'url': 'https://files.jamfconnect.com/JamfConnect.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectLogin/downloads/Jamf Connect Login.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectLogin/downloads/Jamf '
                        'Connect Login.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: JAMF Software '
                                        '(483DWKW443)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectLogin/downloads/Jamf '
                         'Connect Login.dmg/* Login/*.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectLogin/downloads/Jamf Connect Login.dmg
Receipt written to ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectLogin/receipts/JamfConnectLogin.pkg-receipt-20210213-233517.plist

The following recipes failed:
    repos/Yohan460-recipes/JAMFConnect/JamfConnectLogin.pkg.recipe
        Error in com.github.yohan460-recipes.pkg.JamfConnectLogin: Processor: CodeSignatureVerifier: Error: Error processing path '/private/tmp/dmg.HFV9Ei/* Login/*.pkg' with glob. 

Nothing downloaded, packaged or imported.
```

## ❌ JAMFConnect/JamfConnectSync.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/Yohan460-recipes/JAMFConnect/JamfConnectSync.pkg.recipe
Processing repos/Yohan460-recipes/JAMFConnect/JamfConnectSync.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Jamf Connect Sync.dmg',
           'url': 'https://files.jamfconnect.com/JamfConnect.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectSync/downloads/Jamf Connect Sync.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectSync/downloads/Jamf '
                        'Connect Sync.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: JAMF Software '
                                        '(483DWKW443)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectSync/downloads/Jamf '
                         'Connect Sync.dmg/* Sync/*.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectSync/downloads/Jamf Connect Sync.dmg
Receipt written to ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectSync/receipts/JamfConnectSync.pkg-receipt-20210213-233524.plist

The following recipes failed:
    repos/Yohan460-recipes/JAMFConnect/JamfConnectSync.pkg.recipe
        Error in com.github.yohan460-recipes.pkg.JamfConnectSync: Processor: CodeSignatureVerifier: Error: Error processing path '/private/tmp/dmg.DM0w5c/* Sync/*.pkg' with glob. 

Nothing downloaded, packaged or imported.
```

## ❌ JAMFConnect/JamfConnectVerify.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/Yohan460-recipes/JAMFConnect/JamfConnectVerify.pkg.recipe
Processing repos/Yohan460-recipes/JAMFConnect/JamfConnectVerify.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Jamf Connect Verify.dmg',
           'url': 'https://files.jamfconnect.com/JamfConnect.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectVerify/downloads/Jamf Connect Verify.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectVerify/downloads/Jamf '
                        'Connect Verify.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: JAMF Software '
                                        '(483DWKW443)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectVerify/downloads/Jamf '
                         'Connect Verify.dmg/* Verify/*.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectVerify/downloads/Jamf Connect Verify.dmg
Receipt written to ~/Library/AutoPkg/Cache/com.github.yohan460-recipes.pkg.JamfConnectVerify/receipts/JamfConnectVerify.pkg-receipt-20210213-233533.plist

The following recipes failed:
    repos/Yohan460-recipes/JAMFConnect/JamfConnectVerify.pkg.recipe
        Error in com.github.yohan460-recipes.pkg.JamfConnectVerify: Processor: CodeSignatureVerifier: Error: Error processing path '/private/tmp/dmg.GYNkUq/* Verify/*.pkg' with glob. 

Nothing downloaded, packaged or imported.
```

